### PR TITLE
chore: implemen get collection composer

### DIFF
--- a/src/external_services/__init__.py
+++ b/src/external_services/__init__.py
@@ -1,0 +1,2 @@
+# flake8: noqa
+from .provider_composer import IProviderComposer, ProviderComposer

--- a/src/external_services/provider_composer.py
+++ b/src/external_services/provider_composer.py
@@ -1,0 +1,45 @@
+import os
+from typing import List
+from abc import ABC, abstractmethod
+
+from src.modules.nft.domain import Collection
+from .etherscan_scraper import EtherScanScraper
+from .opensea import OpenSea
+
+
+class IProviderComposer(ABC):
+    @abstractmethod
+    def fetch_collections(
+        self, page: int = 1, page_size: int = 100,
+    ) -> List[Collection]:
+        pass
+
+
+class ProviderComposer(IProviderComposer):
+    def __init__(self):
+        self.etherscan = EtherScanScraper(os.getenv('ETHER_SCAN_HOST'))
+        self.opensea = OpenSea(
+            base_url=os.getenv('OPENSEA_HOST'),
+            api_key=os.getenv('OPENSEA_KEY'),
+        )
+
+    def fetch_collections(
+        self, page: int = 1, page_size: int = 100,
+    ) -> List[Collection]:
+        results = self.etherscan.get_all_collections(
+            page=page,
+            page_size=page_size,
+        )
+
+        collections = [
+            self._fetch_collection_metadata(
+                r['contract_address'].lower()
+            )
+            for r in results
+        ]
+
+        return collections
+
+    def _fetch_collection_metadata(self, contract_address: str) -> Collection:
+        response = self.opensea.get_collection_metadata(contract_address)
+        return Collection.create(response)

--- a/tests/external_services/test_provider_composer.py
+++ b/tests/external_services/test_provider_composer.py
@@ -1,0 +1,10 @@
+from src.external_services import ProviderComposer
+
+
+class TestProviderComposer:
+    def test_get_all_collections(self):
+        client = ProviderComposer()
+        # test with small page_size (10) for faster result
+        response = client.fetch_collections(page=1, page_size=10)
+
+        assert len(response) == 10


### PR DESCRIPTION
The goal here is to get top collections up-to-date and as fast as possible.

So the solution is, get list collection from etherscan first becasue these collections are ordered by 24H transfers, then fetch detail metadata from opensea (reduce efforts to parsing html)